### PR TITLE
No-Jira: avoid modifying string literals

### DIFF
--- a/lib/invoca/utils/diff.rb
+++ b/lib/invoca/utils/diff.rb
@@ -88,11 +88,11 @@ module Invoca
                   curr_diff = summary.shift
                 end
                 unless curr_diff && (curr_diff[1].first..curr_diff[1].last) === index
-                  result << "  #{format arg}\n" unless arg.nil? || options[:short_description]
+                  result += "  #{format arg}\n" unless arg.nil? || options[:short_description]
                 end
                 if curr_diff && curr_diff[1].first == index
                   verb, _a_range, _b_range, del, add = curr_diff
-                  result <<
+                  result +=
                     case verb
                     when 'd'
                       del.map { |t| "- #{format t}\n" }.join


### PR DESCRIPTION
This broke as part of https://github.com/Invoca/invoca-utils/pull/8/commits/fb6eb3b0693c86eb3273830692b3c80066905f07 (https://github.com/Invoca/invoca-utils/pull/8)

Here are some alternatives to these changes that I considered:
1. Remove `# frozen_string_literal: true` from `lib/invoca/utils/diff.rb`. This is copy-and-pasted code, we should aim to change it minimally and avoid policy changes like adding `# frozen_string_literal: true`; especially since there is no test coverage. That said, this change seems safe-ish for the time being and is definitely better.
2. Remove this class entirely. I'm sure there are other gems out there that provide this functionality. I chose not to do this strictly as matter of reducing scope and unblocking this gem from being pulled into Web. I started a Slack thread for this discussion: https://invoca.slack.com/archives/C02B56QL1/p1584394296254000