### PR TITLE
fix rescue syntax for Ruby < 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2020-06-17
+### Fixed
+- Support Ruby < 2.5 by adding `begin`/`end` around `rescue` in `retry_on_exception`. 
+
 ## [0.4.0] - 2020-06-09
 ### Added
 - Added `Invoca::Utils.retry_on_exception`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    invoca-utils (0.4.0)
+    invoca-utils (0.4.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/invoca/utils/exceptions.rb
+++ b/lib/invoca/utils/exceptions.rb
@@ -13,9 +13,11 @@ module Invoca
       # @return the value from yield
       def retry_on_exception(exception_classes, retries: 1, before_retry: nil)
         retries.times do |attempt_number|
-          return yield(attempt_number)
-        rescue *Array(exception_classes) => ex
-          before_retry&.call(ex)
+          begin
+            return yield(attempt_number)
+          rescue *Array(exception_classes) => ex
+            before_retry&.call(ex)
+          end
         end
 
         yield(retries)   # no rescue for this last try, so any exceptions will raise out

--- a/lib/invoca/utils/version.rb
+++ b/lib/invoca/utils/version.rb
@@ -2,6 +2,6 @@
 
 module Invoca
   module Utils
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end


### PR DESCRIPTION
## [0.4.1] - 2020-06-17
### Fixed
- Support Ruby < 2.5 by adding `begin`/`end` around `rescue` in `retry_on_exception`. 

Easiest to review with whitespace hidden: https://github.com/Invoca/invoca-utils/pull/15/files?diff=unified&w=1