### PR TITLE
WEB-8121: depend on diff-lcs so that we can share the global namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 **Note:** This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.1] - Unreleased
+## [0.6.1] - 2025-03-27
 ### Fixed
 - Fixed a global namespace collision with diff-lcs over the `Diff` constant
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 **Note:** This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - Unreleased
+### Fixed
+- Fixed a global namespace collision with diff-lcs over the `Diff` constant
+
+### Added
+- Loading `invoca/utils/diff` now gives access to both `invoca-utils` and `diff-lcs` diff helpers
+
 ## [0.6.0] - 2024-07-10
 ### Added
 - Require Ruby > 3.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     invoca-utils (0.6.0)
       activesupport (>= 6.0)
+      diff-lcs (>= 1.6.1)
 
 GEM
   remote: https://rubygems.org/
@@ -27,7 +28,7 @@ GEM
     bigdecimal (3.1.8)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
-    diff-lcs (1.5.1)
+    diff-lcs (1.6.1)
     drb (2.2.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
@@ -40,7 +41,7 @@ GEM
       rspec-mocks (~> 3.13.0)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.1)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-mocks (3.13.1)

--- a/invoca-utils.gemspec
+++ b/invoca-utils.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1"
 
   spec.add_dependency "activesupport", ">= 6.0"
+  spec.add_dependency "diff-lcs", ">= 1.6.1"
 
   # Specify this gem's development and test dependencies in Gemfile
 end

--- a/lib/invoca/utils.rb
+++ b/lib/invoca/utils.rb
@@ -20,9 +20,7 @@ require "invoca/utils/exceptions"
 require "invoca/utils/guaranteed_utf8_string"
 require "invoca/utils/version"
 
-unless defined?(Diff)
-  Diff = Invoca::Utils::Diff
-end
+Diff = Invoca::Utils::Diff
 
 unless defined?(Diffable)
   Diffable = Invoca::Utils::Diffable

--- a/lib/invoca/utils/diff.rb
+++ b/lib/invoca/utils/diff.rb
@@ -2,9 +2,13 @@
 
 # adapted from http://users.cybercity.dk/~dsl8950/ruby/diff-0.3.tar.gz
 
+require "diff/lcs"
+
 module Invoca
   module Utils
     class Diff
+
+      LCS = ::Diff::LCS
 
       VERSION = 0.3
 

--- a/spec/unit/utils_spec.rb
+++ b/spec/unit/utils_spec.rb
@@ -30,8 +30,13 @@ describe Invoca::Utils do
         load 'invoca/utils.rb'
       end
 
-      it "not define Diff as Invoca::Utils::Diff" do
-        expect(@class).to eq(::Diff)
+      it "define Diff as Invoca::Utils::Diff" do
+        expect(Invoca::Utils::Diff).to eq(::Diff)
+      end
+
+      it "still allows access to diff-lcs methods" do
+        expect(defined?(Diff::LCS)).to eq("constant")
+        expect(Diff::LCS).to respond_to(:diff)
       end
     end
 


### PR DESCRIPTION
## [0.6.1]
### Fixed
- Fixed a global namespace collision with diff-lcs over the `Diff` constant

### Added
- Loading `invoca/utils/diff` now gives access to both `invoca-utils` and `diff-lcs` diff helpers

## Demo
Tested this change locally with the call_artifact_push repo

```
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+PATH
+  remote: ../invoca-utils
+  specs:
+    invoca-utils (0.6.0)
+      activesupport (>= 6.0)
+      diff-lcs (>= 1.6.1)
+
 PATH
   remote: .
   specs:
@@ -167,7 +174,7 @@ GEM
-    diff-lcs (1.5.1)
+    diff-lcs (1.6.1)

> bundle exec rspec
/Users/dcaddell/invoca/invoca-utils/lib/invoca/utils.rb:23: warning: already initialized constant Diff
/Users/dcaddell/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/diff-lcs-1.6.1/lib/diff/lcs.rb:3: warning: previous definition of Diff was here
.........................................................................................................................................................................................................................................................................................................................................

Finished in 1.83 seconds (files took 2.61 seconds to load)
329 examples, 0 failures

Coverage report generated for RSpec to /Users/dcaddell/invoca/call_artifact_push/spec/results/coverage/coverage.json. 1120 / 1145 LOC (97.82%) covered.
Coverage report generated for RSpec to /Users/dcaddell/invoca/call_artifact_push/spec/results/coverage. 1120 / 1145 LOC (97.82%) covered.
```