### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 **Note:** This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0] - UNRELEASED
+## [0.7.0] - 2026-06-17
 ### Removed
 - Global `Diff` and `Diffable` constants; use `Invoca::Utils::Diff` and `Invoca::Utils::Diffable` instead
 - Runtime dependency on `diff-lcs`; callers needing `Diff::LCS` should depend on and require `diff-lcs` directly

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    invoca-utils (0.7.0.colin.1)
+    invoca-utils (0.7.0)
       activesupport (>= 6.0)
 
 GEM
@@ -79,4 +79,4 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.4)
 
 BUNDLED WITH
-   2.6.3
+   2.6.5

--- a/lib/invoca/utils/version.rb
+++ b/lib/invoca/utils/version.rb
@@ -2,6 +2,6 @@
 
 module Invoca
   module Utils
-    VERSION = "0.7.0.colin.1"
+    VERSION = "0.7.0"
   end
 end


### PR DESCRIPTION
## Summary
- Set version to `0.7.0` and date the CHANGELOG entry after OCTO-322 merge

## Test plan
- [ ] Merge this PR
- [ ] Run `rake release` from master to publish to RubyGems and push tag `v0.7.0`

Made with [Cursor](https://cursor.com)